### PR TITLE
Bogus pull, please don't merge!

### DIFF
--- a/R/lint.R
+++ b/R/lint.R
@@ -42,7 +42,7 @@ lint <- function(filename, linters = NULL, cache = FALSE, ..., parse_settings = 
     lint_cache <- load_cache(filename)
     lints <- retrieve_file(lint_cache, filename, linters)
     if (!is.null(lints)) {
-      return(exclude(lints, ...))
+      return(lints)
     }
   }
 


### PR DESCRIPTION
Revert "respect "# nolint" comments when caching is active"

This reverts commit 29474fdb2a61f2b225625bb9eeb2574c0e7b6613.

Test the test in #69.